### PR TITLE
Public constructors for jackson parsing

### DIFF
--- a/src/main/java/es/craftsmanship/toledo/katangapp/models/BusStop.java
+++ b/src/main/java/es/craftsmanship/toledo/katangapp/models/BusStop.java
@@ -22,7 +22,11 @@ import es.craftsmanship.toledo.katangapp.business.UnreferenceablePointException;
 @JsonPropertyOrder(alphabetic = true)
 public class BusStop implements ReferenceablePoint {
 
+	/**
+	 * Public empty constructor for automatic Jackson parsing
+	 */
 	public BusStop() {
+		super();
 	}
 
 	public BusStop(

--- a/src/main/java/es/craftsmanship/toledo/katangapp/models/BusStop.java
+++ b/src/main/java/es/craftsmanship/toledo/katangapp/models/BusStop.java
@@ -2,6 +2,7 @@ package es.craftsmanship.toledo.katangapp.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import es.craftsmanship.toledo.katangapp.business.UnreferenceablePointException;
 
 /**
@@ -118,7 +119,7 @@ public class BusStop implements ReferenceablePoint {
 
 	private String address;
 
-	@JsonIgnore
+	@JsonUnwrapped
 	private Point point;
 
 }

--- a/src/main/java/es/craftsmanship/toledo/katangapp/models/BusStopResult.java
+++ b/src/main/java/es/craftsmanship/toledo/katangapp/models/BusStopResult.java
@@ -17,6 +17,13 @@ import java.util.List;
  */
 public class BusStopResult {
 
+	/**
+	 * Public empty constructor for automatic Jackson parsing
+	 */
+	public BusStopResult() {
+		super();
+	}
+
 	public BusStopResult(
 		double distance, BusStop busStop, List<RouteResult> results) {
 

--- a/src/main/java/es/craftsmanship/toledo/katangapp/models/Point.java
+++ b/src/main/java/es/craftsmanship/toledo/katangapp/models/Point.java
@@ -16,6 +16,13 @@ import es.craftsmanship.toledo.katangapp.business.UnreferenceablePointException;
 @JsonPropertyOrder(alphabetic = true)
 public class Point implements ReferenceablePoint {
 
+	/**
+	 * Public empty constructor for automatic Jackson parsing
+	 */
+	public Point() {
+		super();
+	}
+
 	public Point(double latitude, double longitude) {
 		this.latitude = latitude;
 		this.longitude = longitude;

--- a/src/main/java/es/craftsmanship/toledo/katangapp/models/QueryResult.java
+++ b/src/main/java/es/craftsmanship/toledo/katangapp/models/QueryResult.java
@@ -16,6 +16,13 @@ import java.util.List;
  */
 public class QueryResult {
 
+	/**
+	 * Public empty constructor for automatic Jackson parsing
+	 */
+	public QueryResult() {
+		super();
+	}
+
 	public QueryResult(List<BusStopResult> results) {
 		this.results = results;
 	}

--- a/src/main/java/es/craftsmanship/toledo/katangapp/models/RouteResult.java
+++ b/src/main/java/es/craftsmanship/toledo/katangapp/models/RouteResult.java
@@ -8,6 +8,13 @@ package es.craftsmanship.toledo.katangapp.models;
  */
 public class RouteResult implements Comparable<RouteResult> {
 
+	/**
+	 * Public empty constructor for automatic Jackson parsing
+	 */
+	public RouteResult() {
+		super();
+	}
+
 	public RouteResult(String routeId, long time) {
 		this.idl = routeId;
 		this.time = time;


### PR DESCRIPTION
Add public empty constructors AND unwrapped annotation for points to automatically parse them.

I don't know it the @JsonUnwrapped breaks something in the backend, can you test it? :P If you can use the annotation instead of parsing manually it will be great :) (I can send a pull!)

This way Android can parse the json response without the need of entities or manual parsing.

But... I still need android specific entities if I want to pass them to another activity and that's the case. I can only pass Serializable/Parcelable objects or primitives :(

Or implement Serializable :P
